### PR TITLE
Corretto17 JDK Fix DL URL and Version

### DIFF
--- a/corretto-jdk-17/corretto17jdk.nuspec
+++ b/corretto-jdk-17/corretto17jdk.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto17jdk</id>
-    <version>17.0.13.111</version>
+    <version>17.0.14.71</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-17</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 17 JDK</title>
     <authors>Amazon</authors>
     <owners>JohanJanssen</owners>
-    <licenseUrl>https://github.com/corretto/corretto-11/blob/develop/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/corretto/corretto-17/blob/develop/LICENSE</licenseUrl>
     <projectUrl>https://aws.amazon.com/corretto/</projectUrl>
     <docsUrl>https://docs.aws.amazon.com/corretto/</docsUrl>
     <mailingListUrl>https://aws.amazon.com/corretto/</mailingListUrl>

--- a/corretto-jdk-17/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-17/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/17.0.13.11.1/amazon-corretto-17.0.13.11.1-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/17.0.14.7.1/amazon-corretto-17.0.14.7.1-windows-x64.msi'
   Checksum64 = 'a263fa6274d694d5ca018a9c673ce684'
   ChecksumType64 = 'md5'
   fileType      = 'msi'


### PR DESCRIPTION
This fix is like your fix for Corretto JDK 21.