### PR TITLE
Fix corretto-sync.sh dead lock

### DIFF
--- a/corretto-jdk-11/corretto11jdk.nuspec
+++ b/corretto-jdk-11/corretto11jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto11jdk</id>
-    <version>null...</version>
+    <version>11.0.26.41</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-11</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 11 JDK</title>

--- a/corretto-jdk-11/corretto11jdk.nuspec
+++ b/corretto-jdk-11/corretto11jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto11jdk</id>
-    <version>null...</version>
+    <version>11.0.27.61</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-11</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 11 JDK</title>

--- a/corretto-jdk-11/corretto11jdk.nuspec
+++ b/corretto-jdk-11/corretto11jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto11jdk</id>
-    <version>11.0.26.41</version>
+    <version>11.0.27.61</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-11</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 11 JDK</title>

--- a/corretto-jdk-11/corretto11jdk.nuspec
+++ b/corretto-jdk-11/corretto11jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto11jdk</id>
-    <version>11.0.26.41</version>
+    <version>null...</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-11</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 11 JDK</title>

--- a/corretto-jdk-11/corretto11jdk.nuspec
+++ b/corretto-jdk-11/corretto11jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto11jdk</id>
-    <version>11.0.27.61</version>
+    <version>null...</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-11</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 11 JDK</title>

--- a/corretto-jdk-11/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-11/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/11.0.27.6.1/amazon-corretto-11.0.27.6.1-windows-x64.msi'
   Checksum64 = 'ff28be0b339bbbabdbb1a51fed9f0183'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-11/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-11/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/11.0.26.4.1/amazon-corretto-11.0.26.4.1-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64.msi'
   Checksum64 = 'cdd32bc5de24fff746f909811fad5725'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-11/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-11/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/11.0.26.4.1/amazon-corretto-11.0.26.4.1-windows-x64.msi'
   Checksum64 = 'cdd32bc5de24fff746f909811fad5725'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-11/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-11/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/11.0.27.6.1/amazon-corretto-11.0.27.6.1-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64.msi'
   Checksum64 = 'ff28be0b339bbbabdbb1a51fed9f0183'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-11/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-11/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/11.0.26.4.1/amazon-corretto-11.0.26.4.1-windows-x64.msi'
-  Checksum64 = 'cdd32bc5de24fff746f909811fad5725'
+  Url64bit = 'https://corretto.aws/downloads/resources/11.0.27.6.1/amazon-corretto-11.0.27.6.1-windows-x64.msi'
+  Checksum64 = 'ff28be0b339bbbabdbb1a51fed9f0183'
   ChecksumType64 = 'md5'
   fileType      = 'msi'
   silentArgs    = "INSTALLLEVEL=3 /quiet"

--- a/corretto-jdk-17/corretto17jdk.nuspec
+++ b/corretto-jdk-17/corretto17jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto17jdk</id>
-    <version>17.0.14.71</version>
+    <version>17.0.15.61</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-17</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 17 JDK</title>

--- a/corretto-jdk-17/corretto17jdk.nuspec
+++ b/corretto-jdk-17/corretto17jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto17jdk</id>
-    <version>null...</version>
+    <version>17.0.15.61</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-17</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 17 JDK</title>

--- a/corretto-jdk-17/corretto17jdk.nuspec
+++ b/corretto-jdk-17/corretto17jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto17jdk</id>
-    <version>17.0.13.111</version>
+    <version>17.0.14.71</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-17</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 17 JDK</title>

--- a/corretto-jdk-17/corretto17jdk.nuspec
+++ b/corretto-jdk-17/corretto17jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto17jdk</id>
-    <version>null...</version>
+    <version>17.0.14.71</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-17</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 17 JDK</title>

--- a/corretto-jdk-17/corretto17jdk.nuspec
+++ b/corretto-jdk-17/corretto17jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto17jdk</id>
-    <version>17.0.15.61</version>
+    <version>null...</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-17</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 17 JDK</title>

--- a/corretto-jdk-17/corretto17jdk.nuspec
+++ b/corretto-jdk-17/corretto17jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto17jdk</id>
-    <version>17.0.14.71</version>
+    <version>null...</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-17</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 17 JDK</title>

--- a/corretto-jdk-17/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-17/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/17.0.14.7.1/amazon-corretto-17.0.14.7.1-windows-x64.msi'
   Checksum64 = 'a263fa6274d694d5ca018a9c673ce684'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-17/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-17/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/17.0.14.7.1/amazon-corretto-17.0.14.7.1-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64.msi'
   Checksum64 = 'a263fa6274d694d5ca018a9c673ce684'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-17/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-17/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/17.0.14.7.1/amazon-corretto-17.0.14.7.1-windows-x64.msi'
-  Checksum64 = 'a263fa6274d694d5ca018a9c673ce684'
+  Url64bit = 'https://corretto.aws/downloads/resources/17.0.15.6.1/amazon-corretto-17.0.15.6.1-windows-x64.msi'
+  Checksum64 = '439b30fdffbf88bc1c5dbe94797bfc95'
   ChecksumType64 = 'md5'
   fileType      = 'msi'
   silentArgs    = "INSTALLLEVEL=3 /quiet"

--- a/corretto-jdk-17/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-17/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/17.0.15.6.1/amazon-corretto-17.0.15.6.1-windows-x64.msi'
   Checksum64 = '439b30fdffbf88bc1c5dbe94797bfc95'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-17/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-17/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/17.0.13.11.1/amazon-corretto-17.0.13.11.1-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/17.0.14.7.1/amazon-corretto-17.0.14.7.1-windows-x64.msi'
   Checksum64 = 'a263fa6274d694d5ca018a9c673ce684'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-17/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-17/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/17.0.15.6.1/amazon-corretto-17.0.15.6.1-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64.msi'
   Checksum64 = '439b30fdffbf88bc1c5dbe94797bfc95'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-21/corretto21jdk.nuspec
+++ b/corretto-jdk-21/corretto21jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto21jdk</id>
-    <version>21.0.7.61</version>
+    <version>null...</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-21</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto JDK</title>

--- a/corretto-jdk-21/corretto21jdk.nuspec
+++ b/corretto-jdk-21/corretto21jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto21jdk</id>
-    <version>null...</version>
+    <version>21.0.6.71</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-21</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto JDK</title>

--- a/corretto-jdk-21/corretto21jdk.nuspec
+++ b/corretto-jdk-21/corretto21jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto21jdk</id>
-    <version>null...</version>
+    <version>21.0.7.61</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-21</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto JDK</title>

--- a/corretto-jdk-21/corretto21jdk.nuspec
+++ b/corretto-jdk-21/corretto21jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto21jdk</id>
-    <version>21.0.6.71</version>
+    <version>21.0.7.61</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-21</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto JDK</title>

--- a/corretto-jdk-21/corretto21jdk.nuspec
+++ b/corretto-jdk-21/corretto21jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto21jdk</id>
-    <version>21.0.6.71</version>
+    <version>null...</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-21</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto JDK</title>

--- a/corretto-jdk-21/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-21/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/21.0.7.6.1/amazon-corretto-21.0.7.6.1-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64.msi'
   Checksum64 = '2c0e92a0de4b7bcdfda82ba665555f25'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-21/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-21/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/21.0.7.6.1/amazon-corretto-21.0.7.6.1-windows-x64.msi'
   Checksum64 = '2c0e92a0de4b7bcdfda82ba665555f25'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-21/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-21/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-windows-x64.msi'
-  Checksum64 = 'ea3bd8e18bbc5e0ea1cd3c47e690ea2b'
+  Url64bit = 'https://corretto.aws/downloads/resources/21.0.7.6.1/amazon-corretto-21.0.7.6.1-windows-x64.msi'
+  Checksum64 = '2c0e92a0de4b7bcdfda82ba665555f25'
   ChecksumType64 = 'md5'
   fileType      = 'msi'
   silentArgs    = "INSTALLLEVEL=3 /quiet"

--- a/corretto-jdk-21/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-21/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64.msi'
   Checksum64 = 'ea3bd8e18bbc5e0ea1cd3c47e690ea2b'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-21/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-21/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/21.0.6.7.1/amazon-corretto-21.0.6.7.1-windows-x64.msi'
   Checksum64 = 'ea3bd8e18bbc5e0ea1cd3c47e690ea2b'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-8/corretto8jdk.nuspec
+++ b/corretto-jdk-8/corretto8jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto8jdk</id>
-    <version>8.442.06.1</version>
+    <version>null...</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-8</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 8 JDK</title>

--- a/corretto-jdk-8/corretto8jdk.nuspec
+++ b/corretto-jdk-8/corretto8jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto8jdk</id>
-    <version>null...</version>
+    <version>8.452.09.2</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-8</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 8 JDK</title>

--- a/corretto-jdk-8/corretto8jdk.nuspec
+++ b/corretto-jdk-8/corretto8jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto8jdk</id>
-    <version>8.452.09.1</version>
+    <version>8.452.09.2</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-8</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 8 JDK</title>

--- a/corretto-jdk-8/corretto8jdk.nuspec
+++ b/corretto-jdk-8/corretto8jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto8jdk</id>
-    <version>8.442.06.1</version>
+    <version>8.452.09.1</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-8</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 8 JDK</title>

--- a/corretto-jdk-8/corretto8jdk.nuspec
+++ b/corretto-jdk-8/corretto8jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto8jdk</id>
-    <version>null...</version>
+    <version>8.442.06.1</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-8</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 8 JDK</title>

--- a/corretto-jdk-8/corretto8jdk.nuspec
+++ b/corretto-jdk-8/corretto8jdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto8jdk</id>
-    <version>8.452.09.2</version>
+    <version>null...</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jdk-8</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 8 JDK</title>

--- a/corretto-jdk-8/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-8/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/8.452.09.2/amazon-corretto-8.452.09.2-windows-x64-jdk.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64-jdk.msi'
   Checksum64 = '10422e3c4e5fa26a9e68a766c56e4545'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-8/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-8/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/8.452.09.1/amazon-corretto-8.452.09.1-windows-x64-jdk.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/8.452.09.2/amazon-corretto-8.452.09.2-windows-x64-jdk.msi'
   Checksum64 = '10422e3c4e5fa26a9e68a766c56e4545'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-8/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-8/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/8.442.06.1/amazon-corretto-8.442.06.1-windows-x64-jdk.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64-jdk.msi'
   Checksum64 = '53a522f0c2e7d8326a4f92b97599a474'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-8/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-8/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/8.442.06.1/amazon-corretto-8.442.06.1-windows-x64-jdk.msi'
-  Checksum64 = '53a522f0c2e7d8326a4f92b97599a474'
+  Url64bit = 'https://corretto.aws/downloads/resources/8.452.09.1/amazon-corretto-8.452.09.1-windows-x64-jdk.msi'
+  Checksum64 = '10422e3c4e5fa26a9e68a766c56e4545'
   ChecksumType64 = 'md5'
   fileType      = 'msi'
   silentArgs    = "INSTALLLEVEL=3 /quiet"

--- a/corretto-jdk-8/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-8/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64-jdk.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/8.452.09.2/amazon-corretto-8.452.09.2-windows-x64-jdk.msi'
   Checksum64 = '10422e3c4e5fa26a9e68a766c56e4545'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk-8/tools/chocolateyinstall.ps1
+++ b/corretto-jdk-8/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64-jdk.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/8.442.06.1/amazon-corretto-8.442.06.1-windows-x64-jdk.msi'
   Checksum64 = '53a522f0c2e7d8326a4f92b97599a474'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jdk/tools/chocolateyinstall.ps1
+++ b/corretto-jdk/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
   Url64bit = 'https://corretto.aws/downloads/resources/21.0.5.11.1/amazon-corretto-21.0.5.11.1-windows-x64.msi'
-  Checksum64 = 'ea3bd8e18bbc5e0ea1cd3c47e690ea2b'
+  Checksum64 = '2c0e92a0de4b7bcdfda82ba665555f25'
   ChecksumType64 = 'md5'
   fileType      = 'msi'
   silentArgs    = "INSTALLLEVEL=3 /quiet"

--- a/corretto-jre-8/corretto8jre.nuspec
+++ b/corretto-jre-8/corretto8jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto8jre</id>
-    <version>8.452.09.2</version>
+    <version>null...</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jre-8</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 8 JRE</title>

--- a/corretto-jre-8/corretto8jre.nuspec
+++ b/corretto-jre-8/corretto8jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto8jre</id>
-    <version>null...</version>
+    <version>8.452.09.2</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jre-8</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 8 JRE</title>

--- a/corretto-jre-8/corretto8jre.nuspec
+++ b/corretto-jre-8/corretto8jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto8jre</id>
-    <version>8.442.06.1</version>
+    <version>8.452.09.1</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jre-8</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 8 JRE</title>

--- a/corretto-jre-8/corretto8jre.nuspec
+++ b/corretto-jre-8/corretto8jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto8jre</id>
-    <version>8.442.06.1</version>
+    <version>null...</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jre-8</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 8 JRE</title>

--- a/corretto-jre-8/corretto8jre.nuspec
+++ b/corretto-jre-8/corretto8jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto8jre</id>
-    <version>null...</version>
+    <version>8.442.06.1</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jre-8</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 8 JRE</title>

--- a/corretto-jre-8/corretto8jre.nuspec
+++ b/corretto-jre-8/corretto8jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>corretto8jre</id>
-    <version>8.452.09.1</version>
+    <version>8.452.09.2</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/corretto-jre-8</packageSourceUrl>
     <iconUrl>https://rawcdn.githack.com/ajshastri/chocolatey-packages/a698d21b3c63b9ff7e01f442f37cdb7ecf89925a/icons/aws-corretto.png</iconUrl>
     <title>Corretto 8 JRE</title>

--- a/corretto-jre-8/tools/chocolateyinstall.ps1
+++ b/corretto-jre-8/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/8.452.09.1/amazon-corretto-8.452.09.1-windows-x64-jre.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/8.452.09.2/amazon-corretto-8.452.09.2-windows-x64-jre.msi'
   Checksum64 = '2db1f565e550dd0cbd0ed556ee99f2c7'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jre-8/tools/chocolateyinstall.ps1
+++ b/corretto-jre-8/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/8.442.06.1/amazon-corretto-8.442.06.1-windows-x64-jre.msi'
-  Checksum64 = 'b7ce92b9044312e5a63698f32bcae31d'
+  Url64bit = 'https://corretto.aws/downloads/resources/8.452.09.1/amazon-corretto-8.452.09.1-windows-x64-jre.msi'
+  Checksum64 = '2db1f565e550dd0cbd0ed556ee99f2c7'
   ChecksumType64 = 'md5'
   fileType      = 'msi'
   silentArgs    = "INSTALLLEVEL=3 /quiet"

--- a/corretto-jre-8/tools/chocolateyinstall.ps1
+++ b/corretto-jre-8/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/8.452.09.2/amazon-corretto-8.452.09.2-windows-x64-jre.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64-jre.msi'
   Checksum64 = '2db1f565e550dd0cbd0ed556ee99f2c7'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jre-8/tools/chocolateyinstall.ps1
+++ b/corretto-jre-8/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64-jre.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/8.442.06.1/amazon-corretto-8.442.06.1-windows-x64-jre.msi'
   Checksum64 = 'b7ce92b9044312e5a63698f32bcae31d'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jre-8/tools/chocolateyinstall.ps1
+++ b/corretto-jre-8/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64-jre.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/8.452.09.2/amazon-corretto-8.452.09.2-windows-x64-jre.msi'
   Checksum64 = '2db1f565e550dd0cbd0ed556ee99f2c7'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/corretto-jre-8/tools/chocolateyinstall.ps1
+++ b/corretto-jre-8/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 $packageArgs = @{
   PackageName = $env:ChocolateyPackageName
-  Url64bit = 'https://corretto.aws/downloads/resources/8.442.06.1/amazon-corretto-8.442.06.1-windows-x64-jre.msi'
+  Url64bit = 'https://corretto.aws/downloads/resources/null/amazon-corretto-null-windows-x64-jre.msi'
   Checksum64 = 'b7ce92b9044312e5a63698f32bcae31d'
   ChecksumType64 = 'md5'
   fileType      = 'msi'

--- a/scripts/corretto-sync.sh
+++ b/scripts/corretto-sync.sh
@@ -28,10 +28,11 @@ function correttodl {
     URLORIG=$(grep -i "url64" corretto-${PACKAGE}-${JVERSION}/tools/chocolateyinstall.ps1 | head -1 | awk -F\' '{print $2}')
 
     echo "{MD5ORIG} is ${MD5ORIG}"
-    if [[ "${MD5NEW}" != "${MD5ORIG}" ]]
+    echo "{VERSIONORIG} is ${VERSIONORIG}"
+    if [[ "${MD5NEW}" != "${MD5ORIG}" || "${VERSIONNEW}" != "${VERSIONORIG}" ]]
     then
         # COMMITYES=TRUE
-        echo "${MD5NEW} is not the same as ${MD5ORIG} for ${DLVERSIONNEW}"
+        echo "${MD5NEW} is not the same as ${MD5ORIG} or ${VERSIONNEW} is not the same as ${VERSIONORIG} for ${DLVERSIONNEW}"
         echo "Updating file corretto-${PACKAGE}-${JVERSION}/tools/chocolateyinstall.ps1 with the new MD5"
         ${SED} -i "s@${MD5ORIG}@${MD5NEW}@g" corretto-${PACKAGE}-${JVERSION}/tools/chocolateyinstall.ps1
         echo "Updating file corretto-${PACKAGE}-${JVERSION}/corretto${JVERSION}${PACKAGE}.nuspec with the new version - ${VERSIONORIG} to ${VERSIONNEW}"


### PR DESCRIPTION
This is a permanent fix for the problems with not updated version strings of corretto packages. The root cause for the problem is using different sources for the md5 hash and the version string as you already suspected here: https://github.com/ajshastri/chocolatey-packages/issues/7

When packages are changing the sources of different providers obviously don't change at the same time. With the old version of the sync script, this hasn't been a problem if the version number changes first (!), because changes are only triggered if there is an md5 hash mismatch.
If the md5 hash source changes first, the old script triggers a change of the hash without changing the versionnumber. This leads to a deadlock, because the workflow that builds the packages checks the downloaded file against the hash. New versionnumbers don't get synced, because only md5hash mismatches trigger syncs.

My fix doesn't change the root cause (different sources), but the condition when new changes do get synced. If the problem with syncing md5 hash only occurs again in the future, the following package build will fail as well if the build gets triggered. But in the next workflow run of the sync job when the version source hopefully is updated as well, the new version gets synced and the package build will work as expected.

Here is an example of a workflow where version number and md5 hash are off (jdk 17): https://github.com/ajshastri/chocolatey-packages/actions/runs/12895096376/job/35955251260