### PR TITLE
feat: Upgrade OpenJDK version to 24.0.1

### DIFF
--- a/OpenJDK/openjdk.nuspec
+++ b/OpenJDK/openjdk.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>openjdk</id>
-    <version>22.0.2</version>
+    <version>24.0.1</version>
     <packageSourceUrl>https://github.com/ajshastri/chocolatey-packages/tree/master/OpenJDK</packageSourceUrl>
     <title>OpenJDK</title>
     <authors>Oracle</authors>

--- a/OpenJDK/tools/chocolateyBeforeModify.ps1
+++ b/OpenJDK/tools/chocolateyBeforeModify.ps1
@@ -1,7 +1,7 @@
 $programFiles = (${env:ProgramFiles}, ${env:ProgramFiles(x86)} -ne $null)[0]
 $installDir = "$programFiles\OpenJDK"
 
-$version = '22.0.2'
+$version = '24.0.1'
 
 $pathToUnInstall = "$installDir\jdk-$version\bin"
 
@@ -12,8 +12,8 @@ $actualPath = [System.Collections.ArrayList](Get-EnvironmentVariable -Name 'Path
 if ($actualPath -contains $pathToUnInstall)
 {
 	Write-Host "PATH environment variable contains $pathToUnInstall. Removing..."
-	
-	$actualPath.Remove($pathToUnInstall)	
+
+	$actualPath.Remove($pathToUnInstall)
 	$newPath =  $actualPath -Join $statementTerminator
 
 	$cmd = "Set-EnvironmentVariable -Name 'Path' -Value `'$newPath`' -Scope 'Machine'"
@@ -24,4 +24,3 @@ if ($actualPath -contains $pathToUnInstall)
         Start-ChocolateyProcessAsAdmin "$cmd"
     }
 }
-

--- a/OpenJDK/tools/chocolateyinstall.ps1
+++ b/OpenJDK/tools/chocolateyinstall.ps1
@@ -2,13 +2,13 @@ $ErrorActionPreference = 'Stop'
 $programFiles = (${env:ProgramFiles}, ${env:ProgramFiles(x86)} -ne $null)[0]
 $installDir = "$programFiles\OpenJDK"
 
-$version = "22.0.2"
+$version = "24.0.1"
 
 $packageArgs = @{
     PackageName      = $env:ChocolateyPackageName
     UnzipLocation    = $targetDir = $installDir
-    Url64            = 'https://download.java.net/java/GA/jdk22.0.2/c9ecb94cd31b495da20a27d4581645e8/9/GPL/openjdk-22.0.2_windows-x64_bin.zip'
-    Checksum64       = 'f2a9b9ab944e71a64637fcdc6b13a1188cf02d4eb9ecf71dc927e98b3e45f5dc'
+    Url64            = 'https://download.java.net/java/GA/jdk24.0.1/24a58e0e276943138bf3e963e6291ac2/9/GPL/openjdk-24.0.1_windows-x64_bin.zip'
+    Checksum64       = '5b842493b454ac3e816bdc3398716d93239b980db977a63685b0c8cd7b15e315'
     ChecksumType64   = 'sha256'
 }
 

--- a/OpenJDK/tools/chocolateyuninstall.ps1
+++ b/OpenJDK/tools/chocolateyuninstall.ps1
@@ -1,7 +1,7 @@
 $programFiles = (${env:ProgramFiles}, ${env:ProgramFiles(x86)} -ne $null)[0]
 $installDir = "$programFiles\OpenJDK"
 
-$version = '22.0.2'
+$version = '24.0.1'
 
 Uninstall-ChocolateyEnvironmentVariable 'JAVA_HOME' 'Machine'
 rm -r "$installDir\jdk-$version"


### PR DESCRIPTION
This commit contains upgrades related to OpenJDK. Specifically, the version of OpenJDK has been updated from 22.0.2 to 24.0.1.

The main differences in the detailed changes below are:
- The version numbers in openjdk.nuspec, chocolateyBeforeModify.ps1, chocolateyinstall.ps1, and chocolateyuninstall.ps1 have been updated to 24.0.1.
- The download URL and the checksum in chocolateyinstall.ps1 has been updated to reflect the new 24.0.1 version.
- Some trailing whitespace has been removed in chocolateyBeforeModify.ps1.

Breaking Changes:
- This update might cause issues with applications and services that strictly depend on OpenJDK version 22.0.2. Please ensure to verify compatibility with version 24.0.1 before updating.

Please refer the OpenJDK 24.0.1 release notes for the detailed changes from version 22.0.2.