### PR TITLE
Fix Temurin JDK and JRE updates

### DIFF
--- a/.github/workflows/temurin-update.yaml
+++ b/.github/workflows/temurin-update.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.GH_PAT || github.token }}
       - id: temurin_sync
@@ -24,4 +24,3 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git commit -a -m "Temurin version update on $(date)" && git push || echo "No changes"
-          

--- a/scripts/temurin-sync.sh
+++ b/scripts/temurin-sync.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 function dljdkfileinfo() {
   curl -s -L -X 'GET' "https://api.foojay.io/disco/v3.0/packages/jdks?version=${1}&distribution=${2}&architecture=amd64&archive_type=msi&operating_system=windows&latest=available" -H 'accept: application/json' | jq -r '.result[] | select(.filename |  contains ("full") | not) | select(.filename |  contains ("lite") | not)';

--- a/scripts/temurin-sync.sh
+++ b/scripts/temurin-sync.sh
@@ -31,27 +31,27 @@ do
     CHECKSUMTYPE=$(echo $JAVADEETS | jq -r .result[].checksum_type)
     DLURL=$(echo $JAVADEETS | jq -r ".result[].direct_download_uri")
     TEMFOLDNAME=${DIST}-${JVERSION}-${JAVATYPE}
-    
+
     SHA256NEW=$(echo $JAVADEETS | jq -r .result[].checksum)
-    
+
     SHA256ORIG=$(grep -i checksum64 ${TEMFOLDNAME}/tools/chocolateyinstall.ps1 | awk -F\' '{print $2}')
     VERSIONORIG=$(grep -i -o -P '(?<=<version>).*(?=</version>)' ${TEMFOLDNAME}/${DIST}${JVERSION}.nuspec)
     URLORIG=$(grep -i "url64" ${TEMFOLDNAME}/tools/chocolateyinstall.ps1 | head -1 | awk -F\' '{print $2}')
 
-    if [[ "${JVERSION}" != "21" ]] || [[ "${JVERSION}" != "25" ]]
+    if [[ "${JVERSION}" != "21" ]] && [[ "${JVERSION}" != "25" ]]
     then
         DLDEETS32=$(dljdkfileinfo32 $JVERSION ${DIST})
         JAVADEETS32=$(curl -s -L -X 'GET' $(echo $DLDEETS32 | jq -r '.links.pkg_info_uri' | head -1))
         JAVAFILE32=$(echo $JAVADEETS32 | jq -r .result[].filename)
         CHECKSUMTYPE32=$(echo $JAVADEETS32 | jq -r .result[].checksum_type)
         DLURL32=$(echo $JAVADEETS32 | jq -r ".result[].direct_download_uri")
-    
+
         SHA256NEW32=$(echo $JAVADEETS32 | jq -r .result[].checksum)
-    
+
         SHA256ORIG32=$(grep -iv "checksumtype\|checksum64" ${TEMFOLDNAME}/tools/chocolateyinstall.ps1 | grep -i checksum | awk -F\' '{print $2}')
         URLORIG32=$(grep -i "url" ${TEMFOLDNAME}/tools/chocolateyinstall.ps1 | grep -i -v "url64" | head -1 | awk -F\' '{print $2}')
     fi
-    
+
     echo "$JVERSION $JAVATYPE has SHA256ORIG $SHA256ORIG and SHA256NEW $SHA256NEW"
     if [[ "${SHA256NEW,,}" != "${SHA256ORIG,,}" ]]
     then
@@ -91,23 +91,23 @@ do
     CHECKSUMTYPE=$(echo $JAVADEETS | jq -r .result[].checksum_type)
     DLURL=$(echo $JAVADEETS | jq -r ".result[].direct_download_uri")
     TEMFOLDNAME=${DIST}-${JVERSION}-${JAVATYPE}
-    
+
     SHA256NEW=$(echo $JAVADEETS | jq -r .result[].checksum)
-    
+
     SHA256ORIG=$(grep -i checksum64 ${TEMFOLDNAME}/tools/chocolateyinstall.ps1 | awk -F\' '{print $2}')
     VERSIONORIG=$(grep -i -o -P '(?<=<version>).*(?=</version>)' ${TEMFOLDNAME}/${DIST}${JVERSION}${JAVATYPE}.nuspec)
     URLORIG=$(grep -i "url64" ${TEMFOLDNAME}/tools/chocolateyinstall.ps1 | head -1 | awk -F\' '{print $2}')
-    
-    if [[ "${JVERSION}" != "21" ]] || [[ "${JVERSION}" != "25" ]]
+
+    if [[ "${JVERSION}" != "21" ]] && [[ "${JVERSION}" != "25" ]]
     then
         DLDEETS32=$(dljrefileinfo32 $JVERSION ${DIST})
         JAVADEETS32=$(curl -s -L -X 'GET' $(echo $DLDEETS32 | jq -r '.links.pkg_info_uri' | head -1))
         JAVAFILE32=$(echo $JAVADEETS32 | jq -r .result[].filename)
         CHECKSUMTYPE32=$(echo $JAVADEETS32 | jq -r .result[].checksum_type)
         DLURL32=$(echo $JAVADEETS32 | jq -r ".result[].direct_download_uri")
-    
+
         SHA256NEW32=$(echo $JAVADEETS32 | jq -r .result[].checksum)
-    
+
         SHA256ORIG32=$(grep -iv "checksumtype\|checksum64" ${TEMFOLDNAME}/tools/chocolateyinstall.ps1 | grep -i checksum | awk -F\' '{print $2}')
         URLORIG32=$(grep -i "url" ${TEMFOLDNAME}/tools/chocolateyinstall.ps1 | grep -i -v "url64" | head -1 | awk -F\' '{print $2}')
     fi

--- a/scripts/temurin-sync.sh
+++ b/scripts/temurin-sync.sh
@@ -55,6 +55,9 @@ do
     echo "$JVERSION $JAVATYPE has SHA256ORIG $SHA256ORIG and SHA256NEW $SHA256NEW"
     if [[ "${SHA256NEW,,}" != "${SHA256ORIG,,}" ]]
     then
+        if [[ -z "$SHA256NEW" ]]; then ( echo "ERROR: SHA256NEW is not set"; exit 1 ) fi
+        if [[ -z "$VERSIONNEW" ]]; then ( echo "ERROR: VERSIONNEW is not set"; exit 1 ) fi
+        if [[ -z "$DLURL" ]]; then ( echo "ERROR: DLURL is not set"; exit 1 ) fi
         # COMMITYES=TRUE
         echo "$SHA256NEW is not the same as $SHA256ORIG for $VERSIONNEW"
         sed -i "s@$SHA256ORIG@$SHA256NEW@g" ${TEMFOLDNAME}/tools/chocolateyinstall.ps1
@@ -63,6 +66,8 @@ do
 
         if [[ "${JVERSION}" != "21" ]]
         then
+            if [[ -z "$SHA256NEW32" ]]; then ( echo "ERROR: SHA256NEW32 is not set"; exit 1 ) fi
+            if [[ -z "$DLURL32" ]]; then ( echo "ERROR: DLURL32 is not set"; exit 1 ) fi
             sed -i "s@$SHA256ORIG32@$SHA256NEW32@g" ${TEMFOLDNAME}/tools/chocolateyinstall.ps1
             sed -i "s@$URLORIG32@$DLURL32@g" ${TEMFOLDNAME}/tools/chocolateyinstall.ps1
         fi
@@ -115,6 +120,9 @@ do
     echo "$JVERSION $JAVATYPE has SHA256ORIG $SHA256ORIG and SHA256NEW $SHA256NEW"
     if [[ "${SHA256NEW,,}" != "${SHA256ORIG,,}" ]]
     then
+        if [[ -z "$SHA256NEW" ]]; then ( echo "ERROR: SHA256NEW is not set"; exit 1 ) fi
+        if [[ -z "$VERSIONNEW" ]]; then ( echo "ERROR: VERSIONNEW is not set"; exit 1 ) fi
+        if [[ -z "$DLURL" ]]; then ( echo "ERROR: DLURL is not set"; exit 1 ) fi
         # COMMITYES=TRUE
         echo "$SHA256NEW is not the same as $SHA256ORIG for $VERSIONNEW"
         sed -i "s@$SHA256ORIG@$SHA256NEW@g" ${TEMFOLDNAME}/tools/chocolateyinstall.ps1
@@ -123,6 +131,8 @@ do
 
         if [[ "${JVERSION}" != "21" ]]
         then
+            if [[ -z "$SHA256NEW32" ]]; then ( echo "ERROR: SHA256NEW32 is not set"; exit 1 ) fi
+            if [[ -z "$DLURL32" ]]; then ( echo "ERROR: DLURL32 is not set"; exit 1 ) fi
             sed -i "s@$SHA256ORIG32@$SHA256NEW32@g" ${TEMFOLDNAME}/tools/chocolateyinstall.ps1
             sed -i "s@$URLORIG32@$DLURL32@g" ${TEMFOLDNAME}/tools/chocolateyinstall.ps1
         fi

--- a/temurin-11-jdk/temurin11.nuspec
+++ b/temurin-11-jdk/temurin11.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin11</id>
-    <version></version>
+    <version>11.0.29.7</version>
     <title>Temurin jdk11 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-11-jdk/temurin11.nuspec
+++ b/temurin-11-jdk/temurin11.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin11</id>
-    <version>11.0.29.7</version>
+    <version>11.0.31.11</version>
     <title>Temurin jdk11 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-11-jdk/tools/chocolateyinstall.ps1
+++ b/temurin-11-jdk/tools/chocolateyinstall.ps1
@@ -8,11 +8,11 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 $packageArgs = @{
   PackageName     = 'Temurin11'
   fileType        = 'msi'
-  Url             = ''
-  Url64bit        = ''
-  Checksum        = ''
+  Url             = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.28%2B6/OpenJDK11U-jdk_x86-32_windows_hotspot_11.0.28_6.msi'
+  Url64bit        = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.29_7.msi'
+  Checksum        = '2d8fd994e252b0bafebb4d86b564b7552a67c824397e52b1a3c221a56325c5c3'
   ChecksumType    = 'sha256'
-  Checksum64      = ''
+  Checksum64      = '219e88a862ccdde521c42d8ebc001cc711279cdef79157b568ec2ae16b3abde0'
   ChecksumType64  = 'sha256'
   SilentArgs      = $pp
 }

--- a/temurin-11-jdk/tools/chocolateyinstall.ps1
+++ b/temurin-11-jdk/tools/chocolateyinstall.ps1
@@ -8,11 +8,11 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 $packageArgs = @{
   PackageName     = 'Temurin11'
   fileType        = 'msi'
-  Url             = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.28%2B6/OpenJDK11U-jdk_x86-32_windows_hotspot_11.0.28_6.msi'
-  Url64bit        = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.29_7.msi'
-  Checksum        = '2d8fd994e252b0bafebb4d86b564b7552a67c824397e52b1a3c221a56325c5c3'
+  Url             = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jdk_x86-32_windows_hotspot_11.0.29_7.msi'
+  Url64bit        = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_x64_windows_hotspot_11.0.31_11.msi'
+  Checksum        = '0b2e49c16d02659e3232a8d3ed4936df8a12af1ff34a87204430da8c3de4ac31'
   ChecksumType    = 'sha256'
-  Checksum64      = '219e88a862ccdde521c42d8ebc001cc711279cdef79157b568ec2ae16b3abde0'
+  Checksum64      = '432d897f39766288a5747ec5f4927136ce89b743df2ab436cf7d230fbbcd596a'
   ChecksumType64  = 'sha256'
   SilentArgs      = $pp
 }

--- a/temurin-11-jre/temurin11jre.nuspec
+++ b/temurin-11-jre/temurin11jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin11jre</id>
-    <version></version>
+    <version>11.0.29.7</version>
     <title>Temurin jre11 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-11-jre/temurin11jre.nuspec
+++ b/temurin-11-jre/temurin11jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin11jre</id>
-    <version>11.0.29.7</version>
+    <version>11.0.31.11</version>
     <title>Temurin jre11 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-11-jre/tools/chocolateyinstall.ps1
+++ b/temurin-11-jre/tools/chocolateyinstall.ps1
@@ -8,11 +8,11 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 $packageArgs = @{
   PackageName     = 'Temurin11jre'
   fileType        = 'msi'
-  Url             = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.28%2B6/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.28_6.msi'
-  Url64bit        = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jre_x64_windows_hotspot_11.0.29_7.msi'
-  Checksum        = 'a0a85f180f68dfdbd6a76ef84c6a5ce00d7dd284c4237157804a77b77d0e2c64'
+  Url             = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.29_7.msi'
+  Url64bit        = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_x64_windows_hotspot_11.0.31_11.msi'
+  Checksum        = 'dec292e1d6e90944d0c4592e3df26d19072025ed34657d67d3456281f7f3026a'
   ChecksumType    = 'sha256'
-  Checksum64      = '2113628e4feb65cc5e399c34bd1a070f8c8b931ef2899b8a7f7ac3179a3d24ce'
+  Checksum64      = 'a047f90b4520cbd53cc74647aff1f23844299e85e3c469159735801e097208ff'
   ChecksumType64  = 'sha256'
   SilentArgs      = $pp
 }

--- a/temurin-11-jre/tools/chocolateyinstall.ps1
+++ b/temurin-11-jre/tools/chocolateyinstall.ps1
@@ -8,11 +8,11 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 $packageArgs = @{
   PackageName     = 'Temurin11jre'
   fileType        = 'msi'
-  Url             = ''
-  Url64bit        = ''
-  Checksum        = ''
+  Url             = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.28%2B6/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.28_6.msi'
+  Url64bit        = 'https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jre_x64_windows_hotspot_11.0.29_7.msi'
+  Checksum        = 'a0a85f180f68dfdbd6a76ef84c6a5ce00d7dd284c4237157804a77b77d0e2c64'
   ChecksumType    = 'sha256'
-  Checksum64      = ''
+  Checksum64      = '2113628e4feb65cc5e399c34bd1a070f8c8b931ef2899b8a7f7ac3179a3d24ce'
   ChecksumType64  = 'sha256'
   SilentArgs      = $pp
 }

--- a/temurin-17-jdk/temurin17.nuspec
+++ b/temurin-17-jdk/temurin17.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin17</id>
-    <version></version>
+    <version>17.0.17.10</version>
     <title>Temurin jdk17 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-17-jdk/temurin17.nuspec
+++ b/temurin-17-jdk/temurin17.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin17</id>
-    <version>17.0.17.10</version>
+    <version>17.0.19.10</version>
     <title>Temurin jdk17 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-17-jdk/tools/chocolateyinstall.ps1
+++ b/temurin-17-jdk/tools/chocolateyinstall.ps1
@@ -8,11 +8,11 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 $packageArgs = @{
   PackageName     = 'Temurin17'
   fileType        = 'msi'
-  Url             = ''
-  Url64bit        = ''
-  Checksum        = ''
+  Url             = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.16%2B8/OpenJDK17U-jdk_x86-32_windows_hotspot_17.0.16_8.msi'
+  Url64bit        = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.17%2B10/OpenJDK17U-jdk_x64_windows_hotspot_17.0.17_10.msi'
+  Checksum        = '3e3516535d75af5fa14471300980ca86be209ed7fbf31a3c24c6f5c5c96ffc50'
   ChecksumType    = 'sha256'
-  Checksum64      = ''
+  Checksum64      = 'df491b4dbad46dcb77fcba22a0edac4c53a89448f699b33a5cdd5349bd5865dd'
   ChecksumType64  = 'sha256'
   SilentArgs      = $pp
 }

--- a/temurin-17-jdk/tools/chocolateyinstall.ps1
+++ b/temurin-17-jdk/tools/chocolateyinstall.ps1
@@ -8,11 +8,11 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 $packageArgs = @{
   PackageName     = 'Temurin17'
   fileType        = 'msi'
-  Url             = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.16%2B8/OpenJDK17U-jdk_x86-32_windows_hotspot_17.0.16_8.msi'
-  Url64bit        = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.17%2B10/OpenJDK17U-jdk_x64_windows_hotspot_17.0.17_10.msi'
-  Checksum        = '3e3516535d75af5fa14471300980ca86be209ed7fbf31a3c24c6f5c5c96ffc50'
+  Url             = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.17%2B10/OpenJDK17U-jdk_x86-32_windows_hotspot_17.0.17_10.msi'
+  Url64bit        = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_windows_hotspot_17.0.19_10.msi'
+  Checksum        = '45a765d3f65f7bff4f98d0361296b301e04b3a44a06bc22203513f8b1ec328bb'
   ChecksumType    = 'sha256'
-  Checksum64      = 'df491b4dbad46dcb77fcba22a0edac4c53a89448f699b33a5cdd5349bd5865dd'
+  Checksum64      = 'ccd97a7e313381a84e3567ffe10ad562884e399cc1fb1b4c5fa417de49efac78'
   ChecksumType64  = 'sha256'
   SilentArgs      = $pp
 }

--- a/temurin-17-jre/temurin17jre.nuspec
+++ b/temurin-17-jre/temurin17jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin17jre</id>
-    <version></version>
+    <version>17.0.17.10</version>
     <title>Temurin jre17 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-17-jre/temurin17jre.nuspec
+++ b/temurin-17-jre/temurin17jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin17jre</id>
-    <version>17.0.17.10</version>
+    <version>17.0.19.10</version>
     <title>Temurin jre17 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-17-jre/tools/chocolateyinstall.ps1
+++ b/temurin-17-jre/tools/chocolateyinstall.ps1
@@ -8,11 +8,11 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 $packageArgs = @{
   PackageName     = 'Temurin17jre'
   fileType        = 'msi'
-  Url             = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.16%2B8/OpenJDK17U-jre_x86-32_windows_hotspot_17.0.16_8.msi'
-  Url64bit        = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.17%2B10/OpenJDK17U-jre_x64_windows_hotspot_17.0.17_10.msi'
-  Checksum        = '47ac8df108d911103a053880a401fc18302b4b9a098814436716deba86cdfb76'
+  Url             = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.17%2B10/OpenJDK17U-jre_x86-32_windows_hotspot_17.0.17_10.msi'
+  Url64bit        = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_x64_windows_hotspot_17.0.19_10.msi'
+  Checksum        = '7aa6462a0d258f21d1bf324a80a2eb5ab8fa7707fd520b875f5c129d45c3ac92'
   ChecksumType    = 'sha256'
-  Checksum64      = '23eea3080b9545915b5af64807fd310ee7227688a179b33859530912cca4c1e6'
+  Checksum64      = 'ead2ed434bee9493b08ba68c8778775e18fa050bb9a8a2ae72498e4efb75e95f'
   ChecksumType64  = 'sha256'
   SilentArgs      = $pp
 }

--- a/temurin-17-jre/tools/chocolateyinstall.ps1
+++ b/temurin-17-jre/tools/chocolateyinstall.ps1
@@ -8,11 +8,11 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 $packageArgs = @{
   PackageName     = 'Temurin17jre'
   fileType        = 'msi'
-  Url             = ''
-  Url64bit        = ''
-  Checksum        = ''
+  Url             = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.16%2B8/OpenJDK17U-jre_x86-32_windows_hotspot_17.0.16_8.msi'
+  Url64bit        = 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.17%2B10/OpenJDK17U-jre_x64_windows_hotspot_17.0.17_10.msi'
+  Checksum        = '47ac8df108d911103a053880a401fc18302b4b9a098814436716deba86cdfb76'
   ChecksumType    = 'sha256'
-  Checksum64      = ''
+  Checksum64      = '23eea3080b9545915b5af64807fd310ee7227688a179b33859530912cca4c1e6'
   ChecksumType64  = 'sha256'
   SilentArgs      = $pp
 }

--- a/temurin-21-jdk/temurin21.nuspec
+++ b/temurin-21-jdk/temurin21.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin21</id>
-    <version>21.0.9.10</version>
+    <version>21.0.11.10</version>
     <title>Temurin jdk21 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-21-jdk/temurin21.nuspec
+++ b/temurin-21-jdk/temurin21.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin21</id>
-    <version></version>
+    <version>21.0.9.10</version>
     <title>Temurin jdk21 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-21-jdk/tools/chocolateyinstall.ps1
+++ b/temurin-21-jdk/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 
 $packageArgs = @{
   PackageName    = 'Temurin21'
-  Url64bit       = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/OpenJDK21U-jdk_x64_windows_hotspot_21.0.9_10.msi'
-  Checksum64     = 'e97f44c7915866c3127565a91373d03adb639916186b24fc5e0f818a3bde8d3f'
+  Url64bit       = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_x64_windows_hotspot_21.0.11_10.msi'
+  Checksum64     = '93a9c20f4ce967d78992edc5e6fdcc250a56019080553d5d20846decb51d9c01'
   ChecksumType64 = 'sha256'
   fileType       = 'msi'
   SilentArgs     = $pp

--- a/temurin-21-jdk/tools/chocolateyinstall.ps1
+++ b/temurin-21-jdk/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 
 $packageArgs = @{
   PackageName    = 'Temurin21'
-  Url64bit       = ''
-  Checksum64     = ''
+  Url64bit       = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/OpenJDK21U-jdk_x64_windows_hotspot_21.0.9_10.msi'
+  Checksum64     = 'e97f44c7915866c3127565a91373d03adb639916186b24fc5e0f818a3bde8d3f'
   ChecksumType64 = 'sha256'
   fileType       = 'msi'
   SilentArgs     = $pp

--- a/temurin-21-jre/temurin21jre.nuspec
+++ b/temurin-21-jre/temurin21jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin21jre</id>
-    <version></version>
+    <version>21.0.9.10</version>
     <title>Temurin jre21 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-21-jre/temurin21jre.nuspec
+++ b/temurin-21-jre/temurin21jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin21jre</id>
-    <version>21.0.9.10</version>
+    <version>21.0.11.10</version>
     <title>Temurin jre21 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-21-jre/tools/chocolateyinstall.ps1
+++ b/temurin-21-jre/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 
 $packageArgs = @{
   PackageName    = 'Temurin21jre'
-  Url64bit       = ''
-  Checksum64     = ''
+  Url64bit       = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/OpenJDK21U-jre_x64_windows_hotspot_21.0.9_10.msi'
+  Checksum64     = '56b167659821fe125ea3b2974b0da1bac725b886b77193629d8ef880d38517e1'
   ChecksumType64 = 'sha256'
   fileType       = 'msi'
   SilentArgs     = $pp

--- a/temurin-21-jre/tools/chocolateyinstall.ps1
+++ b/temurin-21-jre/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 
 $packageArgs = @{
   PackageName    = 'Temurin21jre'
-  Url64bit       = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/OpenJDK21U-jre_x64_windows_hotspot_21.0.9_10.msi'
-  Checksum64     = '56b167659821fe125ea3b2974b0da1bac725b886b77193629d8ef880d38517e1'
+  Url64bit       = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_x64_windows_hotspot_21.0.11_10.msi'
+  Checksum64     = '570b2b7f4d39638afe416e14285e08f27fd14995e0716dcbc07f936a5b91868a'
   ChecksumType64 = 'sha256'
   fileType       = 'msi'
   SilentArgs     = $pp

--- a/temurin-25-jdk/temurin25.nuspec
+++ b/temurin-25-jdk/temurin25.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin25</id>
-    <version></version>
+    <version>25.0.1.8</version>
     <title>Temurin jdk25 hotspot</title>
     <authors>Adoptium</authors>
     <owners>linearreg</owners>

--- a/temurin-25-jdk/temurin25.nuspec
+++ b/temurin-25-jdk/temurin25.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin25</id>
-    <version>25.0.1.8</version>
+    <version>25.0.3.9</version>
     <title>Temurin jdk25 hotspot</title>
     <authors>Adoptium</authors>
     <owners>linearreg</owners>

--- a/temurin-25-jdk/tools/chocolateyinstall.ps1
+++ b/temurin-25-jdk/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 
 $packageArgs = @{
   PackageName    = 'Temurin25'
-  Url64bit       = 'https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.1%2B8/OpenJDK25U-jdk_x64_windows_hotspot_25.0.1_8.msi'
-  Checksum64     = 'c49e19ba5b47bf119402b1e0a0a71ce5b19ddd9e4ac3e038ea99fe648bd0b3f9'
+  Url64bit       = 'https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_windows_hotspot_25.0.3_9.msi'
+  Checksum64     = '4027451a84f7871a07a5e1d07b77914ca5d6bac91ca9f7026c1b1553701a0876'
   ChecksumType64 = 'sha256'
   fileType       = 'msi'
   SilentArgs     = $pp

--- a/temurin-25-jdk/tools/chocolateyinstall.ps1
+++ b/temurin-25-jdk/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 
 $packageArgs = @{
   PackageName    = 'Temurin25'
-  Url64bit       = ''
-  Checksum64     = ''
+  Url64bit       = 'https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.1%2B8/OpenJDK25U-jdk_x64_windows_hotspot_25.0.1_8.msi'
+  Checksum64     = 'c49e19ba5b47bf119402b1e0a0a71ce5b19ddd9e4ac3e038ea99fe648bd0b3f9'
   ChecksumType64 = 'sha256'
   fileType       = 'msi'
   SilentArgs     = $pp

--- a/temurin-25-jre/temurin25jre.nuspec
+++ b/temurin-25-jre/temurin25jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin25jre</id>
-    <version></version>
+    <version>25.0.1.8</version>
     <title>Temurin jre25 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-25-jre/temurin25jre.nuspec
+++ b/temurin-25-jre/temurin25jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin25jre</id>
-    <version>25.0.1.8</version>
+    <version>25.0.3.9</version>
     <title>Temurin jre25 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-25-jre/tools/chocolateyinstall.ps1
+++ b/temurin-25-jre/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 
 $packageArgs = @{
   PackageName    = 'Temurin25jre'
-  Url64bit       = 'https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.1%2B8/OpenJDK25U-jre_x64_windows_hotspot_25.0.1_8.msi'
-  Checksum64     = '54593f49cff797827dc5d51c3257feb828decba9b70bb270f6c6d5bba91efd56'
+  Url64bit       = 'https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_x64_windows_hotspot_25.0.3_9.msi'
+  Checksum64     = '05975ec0d4df8722b30836af98d795a80f72d4cc37a2451943bd23304d5ac0fb'
   ChecksumType64 = 'sha256'
   fileType       = 'msi'
   SilentArgs     = $pp

--- a/temurin-25-jre/tools/chocolateyinstall.ps1
+++ b/temurin-25-jre/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 
 $packageArgs = @{
   PackageName    = 'Temurin25jre'
-  Url64bit       = ''
-  Checksum64     = ''
+  Url64bit       = 'https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.1%2B8/OpenJDK25U-jre_x64_windows_hotspot_25.0.1_8.msi'
+  Checksum64     = '54593f49cff797827dc5d51c3257feb828decba9b70bb270f6c6d5bba91efd56'
   ChecksumType64 = 'sha256'
   fileType       = 'msi'
   SilentArgs     = $pp

--- a/temurin-8-jdk/temurin8.nuspec
+++ b/temurin-8-jdk/temurin8.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin8</id>
-    <version></version>
+    <version>8.472.8</version>
     <title>Temurin jdk8 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-8-jdk/temurin8.nuspec
+++ b/temurin-8-jdk/temurin8.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin8</id>
-    <version>8.472.8</version>
+    <version>8.492.9</version>
     <title>Temurin jdk8 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-8-jdk/tools/chocolateyinstall.ps1
+++ b/temurin-8-jdk/tools/chocolateyinstall.ps1
@@ -8,11 +8,11 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 $packageArgs = @{
   PackageName     = 'Temurin8'
   fileType        = 'msi'
-  Url             = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u462-b08/OpenJDK8U-jdk_x86-32_windows_hotspot_8u462b08.msi'
-  Url64bit        = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u472-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u472b08.msi'
-  Checksum        = 'bde76537146dddddafa6bcaeb603af173e4144084f8ab3337d575da84604a72b'
+  Url             = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u472-b08/OpenJDK8U-jdk_x86-32_windows_hotspot_8u472b08.msi'
+  Url64bit        = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_x64_windows_hotspot_8u492b09.msi'
+  Checksum        = 'daff0b3a7892ec99635f54554070ede99c175c157f683bc99c6d9008e81dfe4f'
   ChecksumType    = 'sha256'
-  Checksum64      = '810c04469e75c2f1cf83091e9dc78497b84e48ad21269291d9b7ff59b5cbb404'
+  Checksum64      = 'e931546f0557e0735472e99c5f0a62d34854ab8a2fee9709bfcbc7ea6dcc5172'
   ChecksumType64  = 'sha256'
   SilentArgs      = $pp
 }

--- a/temurin-8-jdk/tools/chocolateyinstall.ps1
+++ b/temurin-8-jdk/tools/chocolateyinstall.ps1
@@ -8,11 +8,11 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 $packageArgs = @{
   PackageName     = 'Temurin8'
   fileType        = 'msi'
-  Url             = ''
-  Url64bit        = ''
-  Checksum        = ''
+  Url             = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u462-b08/OpenJDK8U-jdk_x86-32_windows_hotspot_8u462b08.msi'
+  Url64bit        = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u472-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u472b08.msi'
+  Checksum        = 'bde76537146dddddafa6bcaeb603af173e4144084f8ab3337d575da84604a72b'
   ChecksumType    = 'sha256'
-  Checksum64      = ''
+  Checksum64      = '810c04469e75c2f1cf83091e9dc78497b84e48ad21269291d9b7ff59b5cbb404'
   ChecksumType64  = 'sha256'
   SilentArgs      = $pp
 }

--- a/temurin-8-jre/temurin8jre.nuspec
+++ b/temurin-8-jre/temurin8jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin8jre</id>
-    <version></version>
+    <version>8.472.8</version>
     <title>Temurin jre8 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-8-jre/temurin8jre.nuspec
+++ b/temurin-8-jre/temurin8jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin8jre</id>
-    <version>8.472.8</version>
+    <version>8.492.9</version>
     <title>Temurin jre8 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-8-jre/tools/chocolateyinstall.ps1
+++ b/temurin-8-jre/tools/chocolateyinstall.ps1
@@ -8,11 +8,11 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 $packageArgs = @{
   PackageName     = 'Temurin8jre'
   fileType        = 'msi'
-  Url             = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u462-b08/OpenJDK8U-jre_x86-32_windows_hotspot_8u462b08.msi'
-  Url64bit        = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u472-b08/OpenJDK8U-jre_x64_windows_hotspot_8u472b08.msi'
-  Checksum        = '341d9bf07b342d4cf4472cbd31d7fa8099d21d4423dbf0ee7c9342d91047c6dd'
+  Url             = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u472-b08/OpenJDK8U-jre_x86-32_windows_hotspot_8u472b08.msi'
+  Url64bit        = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_x64_windows_hotspot_8u492b09.msi'
+  Checksum        = 'a469a375c2a2358dd86bdfbb8237756c3897f6c4259af7418b0bd626a259e360'
   ChecksumType    = 'sha256'
-  Checksum64      = '2099c63f97bab0dea8c70fb2f32a7a8a2ad8e53167f0523f42c8f62d03bcc66a'
+  Checksum64      = 'b606dcaef8d8896be34e18dbd536437b03761411c7b0a992bcdd6c0962a53edc'
   ChecksumType64  = 'sha256'
   SilentArgs      = $pp
 }

--- a/temurin-8-jre/tools/chocolateyinstall.ps1
+++ b/temurin-8-jre/tools/chocolateyinstall.ps1
@@ -8,11 +8,11 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 $packageArgs = @{
   PackageName     = 'Temurin8jre'
   fileType        = 'msi'
-  Url             = ''
-  Url64bit        = ''
-  Checksum        = ''
+  Url             = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u462-b08/OpenJDK8U-jre_x86-32_windows_hotspot_8u462b08.msi'
+  Url64bit        = 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u472-b08/OpenJDK8U-jre_x64_windows_hotspot_8u472b08.msi'
+  Checksum        = '341d9bf07b342d4cf4472cbd31d7fa8099d21d4423dbf0ee7c9342d91047c6dd'
   ChecksumType    = 'sha256'
-  Checksum64      = ''
+  Checksum64      = '2099c63f97bab0dea8c70fb2f32a7a8a2ad8e53167f0523f42c8f62d03bcc66a'
   ChecksumType64  = 'sha256'
   SilentArgs      = $pp
 }

--- a/temurin-jdk/temurin.nuspec
+++ b/temurin-jdk/temurin.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin</id>
-    <version></version>
+    <version>21.0.9.10</version>
     <title>Temurin jdk21 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-jdk/temurin.nuspec
+++ b/temurin-jdk/temurin.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurin</id>
-    <version>21.0.9.10</version>
+    <version>21.0.11.10</version>
     <title>Temurin jdk21 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-jdk/tools/chocolateyinstall.ps1
+++ b/temurin-jdk/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 
 $packageArgs = @{
   PackageName    = 'Temurin'
-  Url64bit       = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/OpenJDK21U-jdk_x64_windows_hotspot_21.0.9_10.msi'
-  Checksum64     = 'e97f44c7915866c3127565a91373d03adb639916186b24fc5e0f818a3bde8d3f'
+  Url64bit       = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_x64_windows_hotspot_21.0.11_10.msi'
+  Checksum64     = '93a9c20f4ce967d78992edc5e6fdcc250a56019080553d5d20846decb51d9c01'
   ChecksumType64 = 'sha256'
   fileType       = 'msi'
   SilentArgs     = $pp

--- a/temurin-jdk/tools/chocolateyinstall.ps1
+++ b/temurin-jdk/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 
 $packageArgs = @{
   PackageName    = 'Temurin'
-  Url64bit       = ''
-  Checksum64     = ''
+  Url64bit       = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/OpenJDK21U-jdk_x64_windows_hotspot_21.0.9_10.msi'
+  Checksum64     = 'e97f44c7915866c3127565a91373d03adb639916186b24fc5e0f818a3bde8d3f'
   ChecksumType64 = 'sha256'
   fileType       = 'msi'
   SilentArgs     = $pp

--- a/temurin-jre/temurinjre.nuspec
+++ b/temurin-jre/temurinjre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurinjre</id>
-    <version></version>
+    <version>21.0.9.10</version>
     <title>Temurin jre21 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-jre/temurinjre.nuspec
+++ b/temurin-jre/temurinjre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Temurinjre</id>
-    <version>21.0.9.10</version>
+    <version>21.0.11.10</version>
     <title>Temurin jre21 hotspot</title>
     <authors>Adoptium</authors>
     <owners>JohanJanssen</owners>

--- a/temurin-jre/tools/chocolateyinstall.ps1
+++ b/temurin-jre/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 
 $packageArgs = @{
   PackageName    = 'Temurinjre'
-  Url64bit       = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/OpenJDK21U-jre_x64_windows_hotspot_21.0.9_10.msi'
-  Checksum64     = '56b167659821fe125ea3b2974b0da1bac725b886b77193629d8ef880d38517e1'
+  Url64bit       = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_x64_windows_hotspot_21.0.11_10.msi'
+  Checksum64     = '570b2b7f4d39638afe416e14285e08f27fd14995e0716dcbc07f936a5b91868a'
   ChecksumType64 = 'sha256'
   fileType       = 'msi'
   SilentArgs     = $pp

--- a/temurin-jre/tools/chocolateyinstall.ps1
+++ b/temurin-jre/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ $parameters = (Get-PackageParameters); $pp = ( Test-PackageParamaters $parameter
 
 $packageArgs = @{
   PackageName    = 'Temurinjre'
-  Url64bit       = ''
-  Checksum64     = ''
+  Url64bit       = 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/OpenJDK21U-jre_x64_windows_hotspot_21.0.9_10.msi'
+  Checksum64     = '56b167659821fe125ea3b2974b0da1bac725b886b77193629d8ef880d38517e1'
   ChecksumType64 = 'sha256'
   fileType       = 'msi'
   SilentArgs     = $pp


### PR DESCRIPTION
The temurin-sync.sh script failed to update the JDK and JRE chocolateyinstall.ps1 and nuspec files, because they currently contain empty version and checksum strings. `sed` fails to replace the empty strings with new values in recent Github Actions runs:

```
sed: -e expression #1, char 0: no previous regular expression
```

I restored the last chocolateyinstall and nuspec revisions that had valid JRE and JDK versions and checksum values.

I added checks to the updater script that will hopefully prevent writing empty values in the future. 